### PR TITLE
Add omnitrust.ca logo and text to all pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,7 @@
                 <!-- Logo -->
                 <div class="logo">
                     <img src="images/omnitrustlogo.png" alt="OmniTrust Logo" class="logo-img">
+                    <span class="logo-text">omnitrust.ca</span>
                 </div>
 
                 <!-- Desktop Navigation -->
@@ -778,6 +779,7 @@
                 <div class="footer-section">
                     <div class="footer-logo">
                         <img src="images/omnitrustlogo.png" alt="OmniTrust Logo" class="footer-logo-img" loading="lazy" decoding="async">
+                        <span class="footer-logo-text">omnitrust.ca</span>
                     </div>
                     <p class="footer-description">
                         Strategic technology solutions for modern business. We partner with SMEs to deliver custom software solutions and drive measurable growth. Serving clients across Canada.

--- a/services/business-optimization.html
+++ b/services/business-optimization.html
@@ -34,7 +34,8 @@
 				<!-- Logo -->
 				<div class="logo">
 					<a href="/">
-						<img src="../logo.png" alt="OmniTrust Logo" class="logo-img">
+						<img src="../images/omnitrustlogo.png" alt="OmniTrust Logo" class="logo-img">
+						<span class="logo-text">omnitrust.ca</span>
 					</a>
 				</div>
 
@@ -457,7 +458,8 @@
 				<!-- Logo and Description -->
 				<div class="footer-section">
 					<div class="footer-logo">
-						<img src="../logo.png" alt="OmniTrust Logo" class="footer-logo-img" loading="lazy" decoding="async">
+						<img src="../images/omnitrustlogo.png" alt="OmniTrust Logo" class="footer-logo-img" loading="lazy" decoding="async">
+						<span class="footer-logo-text">omnitrust.ca</span>
 					</div>
 					<p class="footer-description">
 						Strategic technology solutions for modern business. We partner with SMEs to deliver custom software solutions and drive measurable growth. Serving clients across Canada.

--- a/services/custom-software-development.html
+++ b/services/custom-software-development.html
@@ -34,7 +34,8 @@
 				<!-- Logo -->
 				<div class="logo">
 					<a href="/">
-						<img src="../logo.png" alt="OmniTrust Logo" class="logo-img">
+						<img src="../images/omnitrustlogo.png" alt="OmniTrust Logo" class="logo-img">
+						<span class="logo-text">omnitrust.ca</span>
 					</a>
 				</div>
 
@@ -457,7 +458,8 @@
 				<!-- Logo and Description -->
 				<div class="footer-section">
 					<div class="footer-logo">
-						<img src="../logo.png" alt="OmniTrust Logo" class="footer-logo-img" loading="lazy" decoding="async">
+						<img src="../images/omnitrustlogo.png" alt="OmniTrust Logo" class="footer-logo-img" loading="lazy" decoding="async">
+						<span class="footer-logo-text">omnitrust.ca</span>
 					</div>
 					<p class="footer-description">
 						Strategic technology solutions for modern business. We partner with SMEs to deliver custom software solutions and drive measurable growth. Serving clients across Canada.

--- a/services/process-digitalization.html
+++ b/services/process-digitalization.html
@@ -34,7 +34,8 @@
 				<!-- Logo -->
 				<div class="logo">
 					<a href="/">
-						<img src="../logo.png" alt="OmniTrust Logo" class="logo-img">
+						<img src="../images/omnitrustlogo.png" alt="OmniTrust Logo" class="logo-img">
+						<span class="logo-text">omnitrust.ca</span>
 					</a>
 				</div>
 
@@ -457,7 +458,8 @@
 				<!-- Logo and Description -->
 				<div class="footer-section">
 					<div class="footer-logo">
-						<img src="../logo.png" alt="OmniTrust Logo" class="footer-logo-img" loading="lazy" decoding="async">
+						<img src="../images/omnitrustlogo.png" alt="OmniTrust Logo" class="footer-logo-img" loading="lazy" decoding="async">
+						<span class="footer-logo-text">omnitrust.ca</span>
 					</div>
 					<p class="footer-description">
 						Strategic technology solutions for modern business. We partner with SMEs to deliver custom software solutions and drive measurable growth. Serving clients across Canada.

--- a/styles.css
+++ b/styles.css
@@ -118,6 +118,26 @@ p {
     width: auto;
 }
 
+.logo {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.logo a {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    text-decoration: none;
+}
+
+.logo-text {
+    color: white;
+    font-size: 1.125rem;
+    font-weight: 600;
+    white-space: nowrap;
+}
+
 .desktop-nav {
     display: none;
 }
@@ -1425,7 +1445,20 @@ p {
 
 .footer-logo-img {
     height: 2rem;
+}
+
+.footer-logo {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
     margin-bottom: 1rem;
+}
+
+.footer-logo-text {
+    color: white;
+    font-size: 1.125rem;
+    font-weight: 600;
+    white-space: nowrap;
 }
 
 .footer-description {


### PR DESCRIPTION
Add 'omnitrust.ca' text next to logos on all pages and correct logo image paths in service pages.

---
<a href="https://cursor.com/background-agent?bcId=bc-b9111511-ba11-404c-ac34-7364196487f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b9111511-ba11-404c-ac34-7364196487f9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

